### PR TITLE
Add double precision implementation in Fortran

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
 g++ -O3 -std=c++11 -o flint flint.cpp -lflint -lstdc++ -lpthread
 g++ -O3 -std=c++11 piranha.cpp -lgmp -lmpfr -lpthread
+gfortran -O3 -march=native -ffast-math -funroll-loops -o double double.f90

--- a/double.f90
+++ b/double.f90
@@ -1,0 +1,86 @@
+program double
+! Compile and run by:
+! gfortran -O3 -march=native -ffast-math -funroll-loops double.f90 && ./a.out
+implicit none
+integer, parameter :: dp = kind(0d0)
+
+real(dp), allocatable :: A(:), B(:), C(:)
+integer :: n, m, i, j, niter
+real(dp) :: prod
+real(dp) :: t1, t2, freq
+n = 1000
+m = n
+allocate(A(0:n-1), B(0:m-1), C(0:n+m-2))
+! sin
+A = 0
+prod = 1
+do i = 0, (n-1)/2
+    j = 2*i+1
+    if (i /= 0) prod = prod * (1-j)
+    prod = prod * j;
+    A(j) = 1._dp / prod
+end do
+! cos
+B(0) = 1
+B(1:) = 0
+prod = 1
+do i = 1, (m-1)/2
+    j = 2*i
+    prod = prod * (1-j)
+    prod = prod * j;
+    B(j) = 1._dp / prod
+end do
+niter = 10000
+call cpu_time(t1)
+do i = 1, niter
+    call poly_mul(A, B, C)
+end do
+call cpu_time(t2)
+print *, "sin(x) ="
+call poly_print(A)
+print *
+print *, "cos(x) ="
+call poly_print(B)
+print *
+print *, "sin(x)*cos(x) ="
+call poly_print(C)
+
+print *, "Total time:", (t2-t1) / niter
+freq = 2.6e9_dp
+print *, "Clock cycles in loop body:", (t2-t1) / niter * freq / (n*m)
+
+contains
+
+subroutine poly_mul(A, B, C)
+real(dp), intent(in) :: A(0:), B(0:)
+real(dp), intent(out) :: C(0:)
+integer :: i, j
+C = 0
+do i = 0, size(A)-1
+    do j = 0, size(B)-1
+        C(i+j) = C(i+j) + A(i)*B(j)
+    end do
+end do
+end subroutine
+
+subroutine poly_print(A)
+real(dp), intent(in) :: A(0:)
+integer :: i
+logical :: first
+first = .true.
+do i = 0, size(A)-1
+    if (abs(A(i)) < tiny(1._dp)) cycle
+    if (.not. first) write(*, "(' +')", advance="no")
+    first = .false.
+    if (i == 0) then
+        write(*, "(es10.2)", advance="no") A(i)
+    else if (i == 1) then
+        write(*, "(es10.2, '*x')", advance="no") A(i)
+    else
+        write(*, "(es10.2, '*x^', i0)", advance="no") A(i), i
+    end if
+end do
+write(*, "(' + O(x^', i0, ')')") size(A)
+end subroutine
+
+end program


### PR DESCRIPTION
On my computer, the output is:

```
$ gfortran -O3 -march=native -ffast-math -funroll-loops double.f90 && ./a.out
 sin(x) =
  1.00E+00*x + -1.67E-01*x^3 +  8.33E-03*x^5 + -1.98E-04*x^7 +  2.76E-06*x^9 + -2.51E-08*x^11 +  1.61E-10*x^13 + -7.65E-13*x^15 +  2.81E-15*x^17 + -8.22E-18*x^19 +  1.96E-20*x^21 + -3.87E-23*x^23 +  6.45E-26*x^25 + -9.18E-29*x^27 +  1.13E-31*x^29 + -1.22E-34*x^31 +  1.15E-37*x^33 + -9.68E-41*x^35 +  7.27E-44*x^37 + -4.90E-47*x^39 +  2.99E-50*x^41 + -1.66E-53*x^43 +  8.36E-57*x^45 + -3.87E-60*x^47 +  1.64E-63*x^49 + -6.45E-67*x^51 +  2.34E-70*x^53 + -7.88E-74*x^55 +  2.47E-77*x^57 + -7.21E-81*x^59 +  1.97E-84*x^61 + -5.04E-88*x^63 +  1.21E-91*x^65 + -2.74E-95*x^67 +  5.84E-99*x^69 + -1.18-102*x^71 +  2.24-106*x^73 + -4.03-110*x^75 +  6.89-114*x^77 + -1.12-117*x^79 +  1.72-121*x^81 + -2.53-125*x^83 +  3.55-129*x^85 + -4.74-133*x^87 +  6.06-137*x^89 + -7.40-141*x^91 +  8.64-145*x^93 + -9.68-149*x^95 +  1.04-152*x^97 + -1.07-156*x^99 +  1.06-160*x^101 + -1.01-164*x^103 +  9.25-169*x^105 + -8.15-173*x^107 +  6.93-177*x^109 + -5.67-181*x^111 +  4.48-185*x^113 + -3.42-189*x^115 +  2.52-193*x^117 + -1.79-197*x^119 +  1.24-201*x^121 + -8.23-206*x^123 +  5.31-210*x^125 + -3.32-214*x^127 +  2.01-218*x^129 + -1.18-222*x^131 +  6.72-227*x^133 + -3.72-231*x^135 +  1.99-235*x^137 + -1.04-239*x^139 +  5.27-244*x^141 + -2.59-248*x^143 +  1.24-252*x^145 + -5.79-257*x^147 +  2.63-261*x^149 + -1.16-265*x^151 +  4.98-270*x^153 + -2.09-274*x^155 +  8.53-279*x^157 + -3.39-283*x^159 +  1.32-287*x^161 + -4.99-292*x^163 +  1.84-296*x^165 + -6.65-301*x^167 +  2.34-305*x^169 + O(x^1000)

 cos(x) =
  1.00E+00 + -5.00E-01*x^2 +  4.17E-02*x^4 + -1.39E-03*x^6 +  2.48E-05*x^8 + -2.76E-07*x^10 +  2.09E-09*x^12 + -1.15E-11*x^14 +  4.78E-14*x^16 + -1.56E-16*x^18 +  4.11E-19*x^20 + -8.90E-22*x^22 +  1.61E-24*x^24 + -2.48E-27*x^26 +  3.28E-30*x^28 + -3.77E-33*x^30 +  3.80E-36*x^32 + -3.39E-39*x^34 +  2.69E-42*x^36 + -1.91E-45*x^38 +  1.23E-48*x^40 + -7.12E-52*x^42 +  3.76E-55*x^44 + -1.82E-58*x^46 +  8.06E-62*x^48 + -3.29E-65*x^50 +  1.24E-68*x^52 + -4.33E-72*x^54 +  1.41E-75*x^56 + -4.25E-79*x^58 +  1.20E-82*x^60 + -3.18E-86*x^62 +  7.88E-90*x^64 + -1.84E-93*x^66 +  4.03E-97*x^68 + -8.35-101*x^70 +  1.63-104*x^72 + -3.02-108*x^74 +  5.30-112*x^76 + -8.83-116*x^78 +  1.40-119*x^80 + -2.10-123*x^82 +  3.02-127*x^84 + -4.13-131*x^86 +  5.39-135*x^88 + -6.73-139*x^90 +  8.04-143*x^92 + -9.20-147*x^94 +  1.01-150*x^96 + -1.06-154*x^98 +  1.07-158*x^100 + -1.04-162*x^102 +  9.71-167*x^104 + -8.72-171*x^106 +  7.55-175*x^108 + -6.30-179*x^110 +  5.06-183*x^112 + -3.93-187*x^114 +  2.95-191*x^116 + -2.13-195*x^118 +  1.49-199*x^120 + -1.01-203*x^122 +  6.64-208*x^124 + -4.22-212*x^126 +  2.59-216*x^128 + -1.55-220*x^130 +  8.94-225*x^132 + -5.02-229*x^134 +  2.73-233*x^136 + -1.45-237*x^138 +  7.43-242*x^140 + -3.71-246*x^142 +  1.80-250*x^144 + -8.51-255*x^146 +  3.91-259*x^148 + -1.75-263*x^150 +  7.63-268*x^152 + -3.24-272*x^154 +  1.34-276*x^156 + -5.40-281*x^158 +  2.12-285*x^160 + -8.13-290*x^162 +  3.04-294*x^164 + -1.11-298*x^166 +  3.96-303*x^168 + -1.38-307*x^170 + O(x^1000)

 sin(x)*cos(x) =
  1.00E+00*x + -6.67E-01*x^3 +  1.33E-01*x^5 + -1.27E-02*x^7 +  7.05E-04*x^9 + -2.57E-05*x^11 +  6.58E-07*x^13 + -1.25E-08*x^15 +  1.84E-10*x^17 + -2.15E-12*x^19 +  2.05E-14*x^21 + -1.62E-16*x^23 +  1.08E-18*x^25 + -6.16E-21*x^27 +  3.04E-23*x^29 + -1.31E-25*x^31 +  4.95E-28*x^33 + -1.66E-30*x^35 +  4.99E-33*x^37 + -1.35E-35*x^39 +  3.29E-38*x^41 + -7.28E-41*x^43 +  1.47E-43*x^45 + -2.72E-46*x^47 +  4.63E-49*x^49 + -7.26E-52*x^51 +  1.05E-54*x^53 + -1.42E-57*x^55 +  1.78E-60*x^57 + -2.08E-63*x^59 +  2.27E-66*x^61 + -2.33E-69*x^63 +  2.24E-72*x^65 + -2.02E-75*x^67 +  1.72E-78*x^69 + -1.39E-81*x^71 +  1.06E-84*x^73 + -7.61E-88*x^75 +  5.20E-91*x^77 + -3.38E-94*x^79 +  2.09E-97*x^81 + -1.23-100*x^83 +  6.87-104*x^85 + -3.67-107*x^87 +  1.87-110*x^89 + -9.16-114*x^91 +  4.28-117*x^93 + -1.92-120*x^95 +  8.24-124*x^97 + -3.40-127*x^99 +  1.34-130*x^101 + -5.12-134*x^103 +  1.88-137*x^105 + -6.61-141*x^107 +  2.25-144*x^109 + -7.36-148*x^111 +  2.33-151*x^113 + -7.10-155*x^115 +  2.09-158*x^117 + -5.96-162*x^119 +  1.64-165*x^121 + -4.38-169*x^123 +  1.13-172*x^125 + -2.82-176*x^127 +  6.84-180*x^129 + -1.61-183*x^131 +  3.66-187*x^133 + -8.09-191*x^135 +  1.74-194*x^137 + -3.62-198*x^139 +  7.34-202*x^141 + -1.45-205*x^143 +  2.77-209*x^145 + -5.16-213*x^147 +  9.37-217*x^149 + -1.65-220*x^151 +  2.85-224*x^153 + -4.77-228*x^155 +  7.79-232*x^157 + -1.24-235*x^159 +  1.93-239*x^161 + -2.92-243*x^163 +  4.31-247*x^165 + -6.22-251*x^167 +  8.76-255*x^169 + -1.21-258*x^171 +  1.62-262*x^173 + -2.13-266*x^175 +  2.73-270*x^177 + -3.43-274*x^179 +  4.21-278*x^181 + -5.06-282*x^183 +  5.95-286*x^185 + -6.84-290*x^187 +  7.70-294*x^189 + -8.49-298*x^191 +  9.16-302*x^193 + -9.63-306*x^195 + O(x^1999)
 Total time:   2.1956670000000000E-004
 Clock cycles in loop body:  0.57087341999999996     
```

As you can see, I am not truncating the series.

The total time is 0.219ms. The multiplication itself is done in this loop:

``` fortran
C = 0
do i = 0, size(A)-1
    do j = 0, size(B)-1
        C(i+j) = C(i+j) + A(i)*B(j)
    end do
end do
```

The theoretical peak performance on my computer (Intel(R) Xeon(R) CPU E5-2650 v2 @ 2.60GHz) is 0.5 clock cycles per double for the inner loop body (since this CPU can only write 2 doubles per clock cycle, that assumes everything is vectorized, and the 0.25 clock cycles for read, add and mul are lower and the CPU does it at the same time, so those are not the bottleneck). The code above runs at 0.57 clock cycles per loop body, so that's about 88% of the peak. This can hardly be made any faster.

So this provides both theoretical and practical upper limit for the performance. Using GMP can only be slower.
